### PR TITLE
fix - puzzle size changed to 6

### DIFF
--- a/cpp/src/config.h
+++ b/cpp/src/config.h
@@ -4,7 +4,7 @@
 
 #include "bb.h"
 
-const int BoardSize = 5;
+const int BoardSize = 6;
 const int PrimaryRow = 2;
 const int PrimarySize = 2;
 const int MinPieceSize = 2;


### PR DESCRIPTION
I think that a 6x6 is standard rush hour puzzle, also the main2 function is does not execute with 5x5 solver and provided sample 6x6 puzzle string.