### PR TITLE
web: disable pull-to-refresh on mobile

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -8,6 +8,7 @@ body {
     position: fixed;
     font-family: sans-serif;
     color: #333;
+    overscroll-behavior-y: contain;
 }
 
 #view {


### PR DESCRIPTION
Hi,
I added a line in style.css to disable pull-to-refresh on mobile, see [this](https://developer.chrome.com/blog/overscroll-behavior/#disabling-pull-to-refresh) and [this](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior) for some documentation of the feature.

Videos demonstrating it on Android Chrome:

https://github.com/fogleman/rush/assets/3199489/03a94f15-4554-4142-bfbe-ade6b1568f68


https://github.com/fogleman/rush/assets/3199489/10a3e4b6-5508-47af-abaf-8afe1583194e

