### PR TITLE
Disable pull down to refresh mobile

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -8,6 +8,7 @@ body {
     position: fixed;
     font-family: sans-serif;
     color: #333;
+    overflow: hidden;
 }
 
 #view {


### PR DESCRIPTION
Pulling down on mobile touch screens to move puzzle pieces triggers the pull down refresh feature which refreshes the page. I disabled this because it is bad and I do not like it. It unfortunately disables pull down refresh entirely which is bad but it's worth it.